### PR TITLE
Use dynamically generated schema, and use specified username field

### DIFF
--- a/ninja_jwt/__init__.py
+++ b/ninja_jwt/__init__.py
@@ -1,3 +1,3 @@
 """Django Ninja JWT - JSON Web Token for Django-Ninja"""
 
-__version__ = "5.1.8"
+__version__ = "5.1.9"

--- a/ninja_jwt/schema.py
+++ b/ninja_jwt/schema.py
@@ -4,10 +4,10 @@ from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import AbstractUser, update_last_login
 from django.utils.translation import gettext_lazy as _
-from ninja.orm import create_schema
-from ninja_jwt.utils import token_error
 from ninja_schema import ModelSchema, Schema
 from pydantic import root_validator
+
+from ninja_jwt.utils import token_error
 
 from . import exceptions
 from .settings import api_settings
@@ -19,7 +19,10 @@ if api_settings.BLACKLIST_AFTER_ROTATION:
 user_name_field = get_user_model().USERNAME_FIELD  # type: ignore
 
 
-AuthUserSchema = create_schema(get_user_model(), fields=[user_name_field])
+class AuthUserSchema(ModelSchema):
+    class Config:
+        model = get_user_model()
+        include = [user_name_field]
 
 
 class TokenObtainSerializer(ModelSchema):

--- a/ninja_jwt/schema.py
+++ b/ninja_jwt/schema.py
@@ -4,10 +4,10 @@ from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import AbstractUser, update_last_login
 from django.utils.translation import gettext_lazy as _
+from ninja.orm import create_schema
+from ninja_jwt.utils import token_error
 from ninja_schema import ModelSchema, Schema
 from pydantic import root_validator
-
-from ninja_jwt.utils import token_error
 
 from . import exceptions
 from .settings import api_settings
@@ -17,6 +17,9 @@ if api_settings.BLACKLIST_AFTER_ROTATION:
     from .token_blacklist.models import BlacklistedToken
 
 user_name_field = get_user_model().USERNAME_FIELD  # type: ignore
+
+
+AuthUserSchema = create_schema(get_user_model(), fields=[user_name_field])
 
 
 class TokenObtainSerializer(ModelSchema):
@@ -69,10 +72,9 @@ class TokenObtainSerializer(ModelSchema):
         )
 
 
-class TokenObtainPairOutput(Schema):
+class TokenObtainPairOutput(AuthUserSchema):
     refresh: str
     access: str
-    username: str
 
 
 class TokenObtainPairSerializer(TokenObtainSerializer):
@@ -97,9 +99,8 @@ class TokenObtainPairSerializer(TokenObtainSerializer):
         return TokenObtainPairOutput(**self.dict(exclude={"password"}))
 
 
-class TokenObtainSlidingOutput(Schema):
+class TokenObtainSlidingOutput(AuthUserSchema):
     token: str
-    username: str
 
 
 class TokenObtainSlidingSerializer(TokenObtainSerializer):


### PR DESCRIPTION
My Django user model does not have a 'username' field, however it is currently hardcoded into the schemas. It was fairly easy to use ninja dynamic model schema to make this field match the 'USERNAME_FIELD' setting.

The change works for my model with just a password and email field, without username field.

I hope this change will be of use to others, relying on dynamic django user model.