### PR TITLE
Draft: add additional fields support, to be used int custom user_authentication_rule

### DIFF
--- a/ninja_jwt/settings.py
+++ b/ninja_jwt/settings.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, Dict
 
 from django.conf import settings
 from django.test.signals import setting_changed
@@ -51,6 +51,7 @@ class NinjaJWTSettings(Schema):
 
     USER_ID_FIELD: str = Field("id")
     USER_ID_CLAIM: str = Field("user_id")
+    ADDITIONAL_FIELDS: Optional[List[Dict]] = Field(None)
 
     USER_AUTHENTICATION_RULE: Any = Field(
         "ninja_jwt.authentication.default_user_authentication_rule"


### PR DESCRIPTION
Hi,

like mentioned in our email conversation here my draft :) 

needs this PR in ninja-schema -> https://github.com/eadwinCode/ninja-schema/pull/4

configured in the settings like:

```python
NINJA_JWT = {
    "ADDITIONAL_FIELDS": [
        {"field_name": "custom_int_field", "field_type": int | None, "field_default": None},
    ],
}
```

with this PR, one can create a `user_authentication_rule` like this:

```python
def user_authentication_rule(user, custom_int_field: int):
    # do something with your custom fields
```


--> tests will follow