### PR TITLE
remove internal use and reference in docs of deprecated `output_schema`

### DIFF
--- a/docs/customizing_token_claims.md
+++ b/docs/customizing_token_claims.md
@@ -26,7 +26,7 @@ class MyTokenObtainPairOutSchema(Schema):
 
 
 class MyTokenObtainPairSchema(TokenObtainPairInputSchema):
-    def output_schema(self):
+    def to_response_schema(self):
         out_dict = self.get_response_schema_init_kwargs()
         out_dict.update(user=UserSchema.from_orm(self._user))
         return MyTokenObtainPairOutSchema(**out_dict)
@@ -38,7 +38,7 @@ class MyTokenObtainPairController(TokenObtainPairController):
         "/pair", response=MyTokenObtainPairOutSchema, url_name="token_obtain_pair"
     )
     def obtain_token(self, user_token: MyTokenObtainPairSchema):
-        return user_token.output_schema()
+        return user_token.to_response_schema()
 
 ```
 

--- a/ninja_jwt/routers/obtain.py
+++ b/ninja_jwt/routers/obtain.py
@@ -18,7 +18,7 @@ sliding_router = Router()
 )
 def obtain_token(request, user_token: schema.obtain_pair_schema):
     user_token.check_user_authentication_rule()
-    return user_token.output_schema()
+    return user_token.to_response_schema()
 
 
 @obtain_pair_router.post(


### PR DESCRIPTION
I noticed that although `output_schema` is deprecated, it was still used in one location and referenced in documentation as in an example. I replaced both of those in favour of `to_response_schema`