### PR TITLE
fixed request context dependency

### DIFF
--- a/ninja_jwt/__init__.py
+++ b/ninja_jwt/__init__.py
@@ -1,3 +1,3 @@
 """Django Ninja JWT - JSON Web Token for Django-Ninja"""
 
-__version__ = "5.3.7"
+__version__ = "5.3.9"

--- a/ninja_jwt/schema.py
+++ b/ninja_jwt/schema.py
@@ -175,7 +175,7 @@ class TokenObtainInputSchemaBase(ModelSchema, TokenInputSchemaMixin):
         values.__dict__.update(token_data=data)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            update_last_login(None, cls._user)
+            update_last_login(None, values._user)
 
     def get_response_schema_init_kwargs(self) -> dict:
         return dict(


### PR DESCRIPTION
## What's changes
- Ensured that request context is available in schema for both `allow` and `forbid` extra pydantic config.