### PR TITLE
Allow for a str or list of strs for AUDIENCE

### DIFF
--- a/ninja_jwt/settings.py
+++ b/ninja_jwt/settings.py
@@ -42,7 +42,7 @@ class NinjaJWTSettings(BaseSettings):
     ALGORITHM: str = Field("HS256")
     SIGNING_KEY: str = Field(settings.SECRET_KEY)
     VERIFYING_KEY: Optional[str] = Field("")
-    AUDIENCE: Optional[str] = Field(None)
+    AUDIENCE: Optional[Union[str,List[str]]] = Field(None)
     ISSUER: Optional[str] = Field(None)
     JWK_URL: Optional[AnyUrl] = Field(None)
     LEEWAY: Union[int, timedelta] = Field(0)


### PR DESCRIPTION
The drf-simplejwt library's TokenBackend [looks like it supports](https://github.com/jazzband/djangorestframework-simplejwt/blob/master/rest_framework_simplejwt/backends.py#L46) either a `str` or a list of `str` for audience, but the `django-ninja-jwt` config restricts the `AUDIENCE` to be a `str` or `None`.

This change relaxes that constraint.