### PR TITLE
Fix return type of the `for_user` method

### DIFF
--- a/ninja_jwt/tokens.py
+++ b/ninja_jwt/tokens.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Optional, Self, Tuple
+from typing import Any, Optional, Tuple, TypeVar
 from uuid import uuid4
 
 from django.conf import settings
@@ -11,6 +11,8 @@ from .exceptions import TokenBackendError, TokenError
 from .settings import api_settings
 from .token_blacklist.models import BlacklistedToken, OutstandingToken
 from .utils import aware_utcnow, datetime_from_epoch, datetime_to_epoch, format_lazy
+
+T = TypeVar("T", bound="Token")
 
 
 class Token:
@@ -181,7 +183,7 @@ class Token:
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
 
     @classmethod
-    def for_user(cls, user: AbstractBaseUser) -> Self:
+    def for_user(cls: T, user: AbstractBaseUser) -> T:
         """
         Returns an authorization token for the given user that will be provided
         after authenticating the user's credentials.
@@ -253,7 +255,7 @@ class BlacklistMixin:
             return BlacklistedToken.objects.get_or_create(token=token)
 
         @classmethod
-        def for_user(cls, user: "AbstractBaseUser") -> Self:
+        def for_user(cls: T, user: "AbstractBaseUser") -> T:
             """
             Adds this token to the outstanding token list.
             """

--- a/ninja_jwt/tokens.py
+++ b/ninja_jwt/tokens.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Self, Tuple
 from uuid import uuid4
 
 from django.conf import settings
@@ -181,7 +181,7 @@ class Token:
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
 
     @classmethod
-    def for_user(cls, user: AbstractBaseUser) -> "Token":
+    def for_user(cls, user: AbstractBaseUser) -> Self:
         """
         Returns an authorization token for the given user that will be provided
         after authenticating the user's credentials.
@@ -253,7 +253,7 @@ class BlacklistMixin:
             return BlacklistedToken.objects.get_or_create(token=token)
 
         @classmethod
-        def for_user(cls, user: "AbstractBaseUser") -> Token:
+        def for_user(cls, user: "AbstractBaseUser") -> Self:
             """
             Adds this token to the outstanding token list.
             """


### PR DESCRIPTION
The `for_user` classmethod returns an instance of `cls()`, but it claims to return `Token`: https://github.com/eadwinCode/django-ninja-jwt/blob/b419409862ac3811a6dc0334d63cc42deac3bbfa/ninja_jwt/tokens.py#L183-L184

To get the access token from `RefreshToken.for_user`, one has to cast the return value in order to make the type checker happy:

```python
refresh_token = cast(RefreshToken, RefreshToken.for_user(user))
access_token = refresh_token.access_token
```

This PR removes the need for that cast by annotating `for_user` to return `Self`, which may be `Token`, or the subclass.
