### PR TITLE
Update CI Python version matrix

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -11,13 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         django-version: ['<3.2', '<3.3', '<4.2', '<4.3', '<5.1', '<5.2', '<5.3']
         exclude:
-          - python-version: '3.8'
-            django-version: '<5.1'
-          - python-version: '3.9'
-            django-version: '<5.1'
           - python-version: '3.12'
             django-version: '<3.2'
           - python-version: '3.12'
@@ -26,6 +22,18 @@ jobs:
             django-version: '<3.2'
           - python-version: '3.13'
             django-version: '<3.3'
+          - python-version: '3.14'
+            django-version: '<3.2'
+          - python-version: '3.14'
+            django-version: '<3.3'
+          - python-version: '3.14'
+            django-version: '<4.2'
+          - python-version: '3.14'
+            django-version: '<4.3'
+          - python-version: '3.14'
+            django-version: '<5.1'
+          - python-version: '3.14'
+            django-version: '<5.2'
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- remove Python 3.8 and 3.9 from the full test matrix
- add Python 3.14 to the full test matrix
- run Python 3.14 only with Django 5.2, the first Django series with official Python 3.14 support

## Why

Python 3.8 and 3.9 are no longer part of the intended CI support window, while Python 3.14 was missing from coverage. Restricting the new runtime to Django 5.2 avoids unsupported Python/Django combinations.

## Impact

The full CI workflow now covers Python 3.10 through 3.14. Package metadata and runtime dependencies are unchanged.

## Validation

- YAML syntax and CI matrix assertions passed
- `git diff --check` passed
- applicable pre-commit checks passed, including `check-yaml`
- Python 3.14.4 / Django 5.2.16: 151 passed, 6 skipped
