### PR TITLE
Prepare v5.4.5 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: '3.13'
       - name: Install Flit
         run: pip install flit
       - name: Install Dependencies

--- a/ninja_jwt/__init__.py
+++ b/ninja_jwt/__init__.py
@@ -1,3 +1,3 @@
 """Django Ninja JWT - JSON Web Token for Django-Ninja"""
 
-__version__ = "5.4.4"
+__version__ = "5.4.5"


### PR DESCRIPTION
## Summary

- bump `django-ninja-jwt` from 5.4.4 to 5.4.5
- update the PyPI publishing runner from Python 3.8 to Python 3.13

## Why

This prepares the next patch release after the Python 3.14 CI update. The publishing workflow should no longer depend on the end-of-life Python 3.8 runtime.

## Impact

Publishing a GitHub release from this commit will build and upload version 5.4.5 to PyPI. Runtime dependencies and package compatibility metadata are unchanged.

## Validation

- release workflow YAML parsed successfully
- Ruff passed for the version module
- applicable pre-commit checks passed, including `check-yaml`
- wheel and source distribution built successfully under Python 3.13
- built wheel metadata reports version 5.4.5
- `git diff --check` passed
