### PR TITLE
Fix mistaken type annotation

### DIFF
--- a/ninja_jwt/tokens.py
+++ b/ninja_jwt/tokens.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Optional, Tuple, TypeVar
+from typing import Any, Optional, Tuple, Type, TypeVar
 from uuid import uuid4
 
 from django.conf import settings
@@ -183,7 +183,7 @@ class Token:
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
 
     @classmethod
-    def for_user(cls: type[T], user: AbstractBaseUser) -> T:
+    def for_user(cls: Type[T], user: AbstractBaseUser) -> T:
         """
         Returns an authorization token for the given user that will be provided
         after authenticating the user's credentials.
@@ -255,7 +255,7 @@ class BlacklistMixin:
             return BlacklistedToken.objects.get_or_create(token=token)
 
         @classmethod
-        def for_user(cls: type[T], user: "AbstractBaseUser") -> T:
+        def for_user(cls: Type[T], user: "AbstractBaseUser") -> T:
             """
             Adds this token to the outstanding token list.
             """

--- a/ninja_jwt/tokens.py
+++ b/ninja_jwt/tokens.py
@@ -183,7 +183,7 @@ class Token:
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
 
     @classmethod
-    def for_user(cls: T, user: AbstractBaseUser) -> T:
+    def for_user(cls: type[T], user: AbstractBaseUser) -> T:
         """
         Returns an authorization token for the given user that will be provided
         after authenticating the user's credentials.
@@ -255,7 +255,7 @@ class BlacklistMixin:
             return BlacklistedToken.objects.get_or_create(token=token)
 
         @classmethod
-        def for_user(cls: T, user: "AbstractBaseUser") -> T:
+        def for_user(cls: type[T], user: "AbstractBaseUser") -> T:
             """
             Adds this token to the outstanding token list.
             """


### PR DESCRIPTION
In https://github.com/eadwinCode/django-ninja-jwt/pull/179 I added a broken type annotation:

```python
    @classmethod
    def for_user(cls: T, user: AbstractBaseUser) -> T:
```

Since `for_user` is a classmethod, its first argument is a class, not an instance. The correct annotation would be:

```python
    @classmethod
    def for_user(cls: Type[T], user: AbstractBaseUser) -> T:
```

I have checked both versions by running `uv tool run --with=. ty check /tmp/typing-sandbox.py ` in the django-ninja-jwt worktree against this sample file:

```python
# /tmp/typing-sandbox.py
from ninja_jwt.tokens import Token, RefreshToken
from django.contrib.auth.models import User

Token().for_user(User())
RefreshToken().for_user(User())
```

Apologies for the mistaken PR – I had tested the change locally but it seems I was not careful 🙈

I would be happy to add `ty check` to CI if that contribution would be accepted.
